### PR TITLE
Modernising Docker Compose Setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ THIS_FILE := $(lastword $(MAKEFILE_LIST))
 
 run:
 	MYSQL_PASS="$(MYSQL_PASS)" docker-compose up -d
-	sleep 5
 	docker exec -t -i opentickets_db_1 mysql -u super -p$(MYSQL_PASS) -e 'create database opentickets'
 	docker exec -t -i opentickets_webapp_1 sh -c 'php /data/vendor/bin/doctrine-module orm:schema-tool:create'
 	docker exec -t -i opentickets_webapp_1 sh -c 'php /data/vendor/bin/cli cqrs:rebuild-projection -a'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,24 @@
-db:
-  image: imhotek/mariadb:0.2.0
-  environment:
-    - MYSQL_USER=super
-    - MYSQL_PASS=${MYSQL_PASS}
-    - DB_NAME=opentickets
-  expose:
-    - 3306
+version: "2.1"
 
-webapp:
-  image: imhotek/webapp:0.7.0
-  ports:
-    - 80
-  links:
-    - db:db
-  volumes:
-    - ./:/data
+services:
+  db:
+    image: imhotek/mariadb:0.2.0
+    environment:
+      MYSQL_USER: super
+      MYSQL_PASS: ${MYSQL_PASS}
+      DB_NAME: opentickets
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 3306"]
+      interval: 2s
+      retries: 10
+      timeout: 1s
+
+  webapp:
+    image: imhotek/webapp:0.7.0
+    ports:
+      - 80
+    volumes:
+      - ./:/data
+    depends_on:
+      db:
+        condition: service_healthy


### PR DESCRIPTION
1. Adopting 2.1 syntax for healthcheck based dependencies
2. Added healthcheck for db. Basic for now, until complex is required
3. Removing redundant sleep