### PR TITLE
Optimise template load using a map

### DIFF
--- a/module/Tickets/config/module.config.php
+++ b/module/Tickets/config/module.config.php
@@ -117,15 +117,16 @@ return [
         'exception_template'       => 'error/index',
         'template_map' => [
             'layout/layout'           => __DIR__ . '/../view/layout/layout.phtml',
-            'application/index/index' => __DIR__ . '/../view/application/index/index.phtml',
             'error/404'               => __DIR__ . '/../view/error/404.phtml',
             'error/index'             => __DIR__ . '/../view/error/index.phtml',
+            'email/receipt'           => __DIR__ . '/../view/email/receipt.phtml',
+            'tickets/ticket/complete' => __DIR__ . '/../view/tickets/ticket/complete.phtml',
+            'tickets/ticket/manage' => __DIR__ . '/../view/tickets/ticket/manage.phtml',
+            'tickets/ticket/purchase' => __DIR__ . '/../view/tickets/ticket/purchase.phtml',
+            'tickets/ticket/select-tickets' => __DIR__ . '/../view/tickets/ticket/select-tickets.phtml',
         ],
         'controller_map' => [
             'OpenTickets\Tickets\Controller' => 'tickets',
-        ],
-        'template_path_stack' => [
-            __DIR__ . '/../view',
         ],
     ],
     'zfc_rbac' => [

--- a/module/Tickets/config/module.config.php
+++ b/module/Tickets/config/module.config.php
@@ -124,6 +124,7 @@ return [
             'tickets/ticket/manage' => __DIR__ . '/../view/tickets/ticket/manage.phtml',
             'tickets/ticket/purchase' => __DIR__ . '/../view/tickets/ticket/purchase.phtml',
             'tickets/ticket/select-tickets' => __DIR__ . '/../view/tickets/ticket/select-tickets.phtml',
+            'tickets/ticket/_orderInformation' => __DIR__ . '/../view/tickets/ticket/_orderInformation.phtml',
         ],
         'controller_map' => [
             'OpenTickets\Tickets\Controller' => 'tickets',

--- a/module/Tickets/view/tickets/ticket/complete.phtml
+++ b/module/Tickets/view/tickets/ticket/complete.phtml
@@ -1,4 +1,4 @@
-<?php include __DIR__ . '/_orderInformation.phtml';?>
+<?= $this->render('tickets/ticket/_orderInformation', ['purchase' => $this->purchase]) ?>
 
 <div class="row">
     <div class="col-xs-12">

--- a/module/Tickets/view/tickets/ticket/purchase.phtml
+++ b/module/Tickets/view/tickets/ticket/purchase.phtml
@@ -10,7 +10,7 @@ $this->inlineScript()
 $this->headLink()->appendStylesheet('/css/card.css');
 ?>
 
-<?php include __DIR__ . '/_orderInformation.phtml';?>
+<?= $this->render('tickets/ticket/_orderInformation', ['purchase' => $this->purchase]) ?>
 <div class="row">
     <div class="col-md-6 col-xs-12">
         <?php $this->form->prepare();?>


### PR DESCRIPTION
Using a template map rather than the template path stack optimise the page load, and there are not many templates here.

I will emit a concern about the `<?php include __DIR__ . '/_orderInformation.phtml';?>` in most templates. I believe it can be replaced with a subview, as demonstrated in the second commit. This allows more flexibility as the view can be defined in config.