### PR TITLE
Fix email receipt encoding problem

### DIFF
--- a/module/Tickets/src/EventListener/EmailPurchase.php
+++ b/module/Tickets/src/EventListener/EmailPurchase.php
@@ -85,6 +85,7 @@ class EmailPurchase implements MessageHandlerInterface
         $text->type = "text/plain";
 */
         $html = new MimePart($htmlMarkup);
+        $html->setCharset('UTF-8');
         $html->type = "text/html";
 
         $body = new MimeMessage();
@@ -96,6 +97,7 @@ class EmailPurchase implements MessageHandlerInterface
         if (isset($this->config['from'])) {
             $message->setFrom($this->config['from']);
         }
+        $message->setEncoding('UTF-8');
 
         return $message;
     }


### PR DESCRIPTION
Fixes a bug on the `£` character encoding on both Gmail and Inbox.

`$message->setEncoding('UTF-8');` is not required (work without for this specific issue), but decided to add it as discussed in this [ZF issue](https://github.com/zendframework/zendframework/issues/5708#issuecomment-188668225).