### PR TITLE
Add ability to set an input filter on forms

### DIFF
--- a/module/Tickets/config/input-filters/manage-ticket.config.php
+++ b/module/Tickets/config/input-filters/manage-ticket.config.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'delegate' => [
+        'type' => \Zend\InputFilter\InputFilter::class,
+        'firstname' => [
+            'required' => false,
+        ],
+        'lastname' => [
+            'required' => false,
+        ],
+        'email' => [
+            'required' => false,
+        ],
+        'company' => [
+            'required' => false,
+        ],
+        'twitter' => [
+            'required' => false,
+        ],
+        'requirements' => [
+            'required' => false,
+        ],
+    ],
+];

--- a/module/Tickets/config/module.config.php
+++ b/module/Tickets/config/module.config.php
@@ -77,6 +77,19 @@ return [
             \OpenTickets\Tickets\Controller\TicketController::class => \OpenTickets\Tickets\Service\Factory\ControllerFactory::class,
         ],
     ],
+    'form_elements' => [
+        'factories' => [
+            \OpenTickets\Tickets\Form\ManageTicket::class => \Zend\ServiceManager\Factory\InvokableFactory::class,
+        ],
+    ],
+    'input_filters' => [
+        'abstract_factories' => [
+            \Zend\InputFilter\InputFilterAbstractServiceFactory::class,
+        ],
+    ],
+    'input_filter_specs' => [
+        \OpenTickets\Tickets\Form\ManageTicket::class => include __DIR__ . '/input-filters/manage-ticket.config.php',
+    ],
     'reports' => [
         'aliases' => [
             'delegate_information' => \OpenTickets\Tickets\Report\DelegateInformation::class,

--- a/module/Tickets/src/Controller/TicketController.php
+++ b/module/Tickets/src/Controller/TicketController.php
@@ -16,6 +16,7 @@ use OpenTickets\Tickets\Domain\ValueObject\Delegate;
 use OpenTickets\Tickets\Domain\ValueObject\TicketReservationRequest;
 use OpenTickets\Tickets\Form\ManageTicket;
 use OpenTickets\Tickets\Form\PurchaseForm;
+use Zend\Form\FormElementManager\FormElementManagerV2Polyfill;
 use Zend\Stdlib\ArrayObject;
 use Zend\View\Model\ViewModel;
 use ZfrStripe\Client\StripeClient;
@@ -41,16 +42,22 @@ class TicketController extends AbstractController
      * @var TicketAvailability
      */
     private $ticketAvailability;
+    /**
+     * @var FormElementManagerV2Polyfill
+     */
+    private $formElementManager;
 
     public function __construct(
         MessageBusInterface $commandBus,
         EntityManager $entityManager,
         StripeClient $stripeClient,
         Configuration $configuration,
-        TicketAvailability $ticketAvailability
+        TicketAvailability $ticketAvailability,
+        FormElementManagerV2Polyfill $formElementManager
     ) {
         parent::__construct($commandBus, $entityManager, $stripeClient, $configuration);
         $this->ticketAvailability = $ticketAvailability;
+        $this->formElementManager = $formElementManager;
     }
 
     public function indexAction()
@@ -276,7 +283,7 @@ class TicketController extends AbstractController
         $ticketRecord = $purchase->getTicketRecord($ticketId);
         $delegate = $ticketRecord->getDelegate();
 
-        $form = new ManageTicket();
+        $form = $this->formElementManager->get(ManageTicket::class);
         $data = [
             'delegate' => [
                 'firstname' => $delegate->getFirstname(),

--- a/module/Tickets/src/Form/FormInputFilterDelegator.php
+++ b/module/Tickets/src/Form/FormInputFilterDelegator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTickets\Tickets\Form;
+
+use Zend\Form\FormElementManager\FormElementManagerV2Polyfill;
+
+final class FormInputFilterDelegator
+{
+    public function __invoke(
+        FormElementManagerV2Polyfill $serviceLocator,
+        string $name,
+        string $requestedName,
+        callable $callback
+    ) {
+        /* @var $form \Zend\Form\FormInterface */
+        $form = call_user_func($callback);
+        $inputFilterManager = $serviceLocator->getServiceLocator()->get('InputFilterManager');
+        if ($inputFilterManager->has(get_class($form))) {
+            /* @var $inputFilter \Zend\InputFilter\InputFilter */
+            $inputFilter = $form->getInputFilter();
+            $inputFilter->merge($inputFilterManager->get(get_class($form)));
+            $form->setInputFilter($inputFilter);
+        }
+        return $form;
+    }
+}

--- a/module/Tickets/src/Form/ManageTicket.php
+++ b/module/Tickets/src/Form/ManageTicket.php
@@ -1,19 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OpenTickets\Tickets\Form;
 
 use OpenTickets\Tickets\Form\Fieldset\DelegateInformation;
 use Zend\Form\Element\Csrf;
 use Zend\Form\Form;
 
-class ManageTicket extends Form
+final class ManageTicket extends Form
 {
     public function __construct()
     {
         parent::__construct('manage-ticket-form');
+    }
 
-        $this->add(['type' => DelegateInformation::class, 'name' => 'delegate']);
+    public function init()
+    {
+        $this->add([
+            'type' => DelegateInformation::class,
+            'name' => 'delegate',
+        ]);
 
-        $this->add(new Csrf('security'));
+        $this->add([
+            'type' => Csrf::class,
+            'name' => 'security',
+        ]);
     }
 }

--- a/module/Tickets/src/Service/Factory/ControllerFactory.php
+++ b/module/Tickets/src/Service/Factory/ControllerFactory.php
@@ -18,7 +18,8 @@ class ControllerFactory implements FactoryInterface
             $serviceLocator->get('doctrine.entitymanager.orm_default'),
             $serviceLocator->get(StripeClient::class),
             $serviceLocator->get(Configuration::class),
-            $serviceLocator->get(TicketAvailability::class)
+            $serviceLocator->get(TicketAvailability::class),
+            $serviceLocator->get('FormElementManager')
         );
     }
 }


### PR DESCRIPTION
Add ability to set validators and filters on the manage ticket form.

In order to do so with following code, one must use a delegator and set the validators in the input filter of the form fully qualified class name. An example is [available here](https://github.com/scotlandphp/opentickets-scotlandphp/blob/master/config/module.config.php#L25)